### PR TITLE
Revise negative relation mining logic

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -41,7 +41,7 @@ def find_no_combination_examples(relations, entities):
     for relation in relations:
         if relation["class"] != NOT_COMB:
             span_idxs = sorted(relation["spans"])
-            entity_cooccurrences.append(tuple(span_idxs))
+            entity_cooccurrences.append(set(span_idxs))
 
     entity_idxs = range(len(entities))
     candidate_no_combinations = powerset(entity_idxs)
@@ -51,7 +51,7 @@ def find_no_combination_examples(relations, entities):
     for candidate in candidate_no_combinations:
         entity_found = False
         for c in entity_cooccurrences:
-            if candidate.issubset(set(c)):
+            if candidate.issubset(c):
                 entity_found = True
         # If a set of drugs is not contained in any other relation, then consider it as an implicit
         # NOT-COMB relation.


### PR DESCRIPTION
Two changes:
1) Remove the logic to transitively construct larger positive combination relations from lower-order subrelations
2) Modify the negative example mining to explicitly enumerate the powerset of all entities, and identify all subsets not found in a relation as NOT-COMB relations.