### PR TITLE
Move model prediction post-processing into train/test_only.py

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -135,12 +135,6 @@ def filter_overloaded_predictions(preds):
     return [x[1] for x in sorted(final_test, key=lambda x: x[0])]
 
 
-def f_score_our_model(gold, test, unify_negs=False, exact_match=False):
-    fixed_gold, fixed_test = adjust_data(gold, test)
-    fixed_test = filter_overloaded_predictions(fixed_test)
-    return f_score(fixed_gold, fixed_test, unify_negs, exact_match)
-
-
 def f_score(gold, test, unify_negs=False, exact_match=False):
     gs, ts = create_vectors(gold, test, unify_negs, exact_match)
     f, p, r = f_from_p_r(gs, ts)

--- a/train.py
+++ b/train.py
@@ -17,8 +17,8 @@ from constants import ENTITY_END_MARKER, ENTITY_START_MARKER, NOT_COMB
 from data_loader import DrugSynergyDataModule
 from model import BertForRelation, RelationExtractor
 from preprocess import create_dataset
-from utils import construct_row_id_idx_mapping, ModelMetadata, save_metadata, set_seed, write_error_analysis_file
-from eval import f_score_our_model
+from utils import construct_row_id_idx_mapping, ModelMetadata, save_metadata, set_seed, write_error_analysis_file, write_jsonl
+from eval import adjust_data, filter_overloaded_predictions, f_score
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--pretrained-lm', type=str, required=False, default="allenai/scibert_scivocab_uncased", help="Path to pretrained Huggingface Transformers model")
@@ -142,6 +142,13 @@ if __name__ == "__main__":
     trainer.test(system, datamodule=dm)
     test_predictions = system.test_predictions
     test_row_ids = [idx_row_id_mapping[row_idx] for row_idx in system.test_row_idxs]
-    _ = f_score_our_model(test_row_ids, test_predictions)
+
+    fixed_gold, fixed_test = adjust_data(test_row_ids, test_predictions)
+    fixed_test = filter_overloaded_predictions(fixed_test)
     os.makedirs("outputs", exist_ok=True)
+    gold_output = os.path.join("outputs", "gold.jsonl")
+    test_output = os.path.join("outputs", args.model_name + "_test.jsonl")
+    write_jsonl(fixed_gold, gold_output)
+    write_jsonl(fixed_test, test_output)
+    _ = f_score(fixed_gold, fixed_test, False, False)
     write_error_analysis_file(test_data, test_data_raw, test_row_ids, test_predictions, os.path.join("outputs", args.model_name + ".tsv"))

--- a/utils.py
+++ b/utils.py
@@ -104,8 +104,11 @@ def read_jsonl(fname: str):
     return list(jsonlines.open(fname))
 
 def write_jsonl(data: List[Dict], fname: str):
-    with jsonlines.Writer(open(fname, 'wb')) as writer:
+    with open(fname, 'wb') as fp:
+        writer = jsonlines.Writer(fp)
         writer.write_all(data)
+    writer.close()
+    fp.close()
     print(f"Wrote {len(data)} json lines to {fname}")
 
 def write_json(data: Dict, fname: str):


### PR DESCRIPTION
Tested with the commands
```
python test_only.py --checkpoint-path checkpoints_more_data_seed_2024_multiclass/ --test-file data/dev_set_error_analysis.jsonl --produce_all_subsets --outputs-directory /tmp/outputs/ --error-analysis-file /tmp/error_analysis.csv
```

and

```
python train.py --pretrained-lm allenai/scibert_scivocab_uncased --num-train-epochs 10 --lr 2e-4 --batch-size 18 --context-window-size 300 --max-seq-length 512 --label2idx data/label2idx.json --model-name baseline_model
```