### PR TITLE
Batchify entity token averaging in model

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytorch_lightning as pl
 from tqdm import tqdm
 import torch
@@ -101,14 +102,18 @@ def construct_dataset(data: List[Dict], tokenizer: AutoTokenizer, row_idx_mappin
         max_entities_length = max(max_entities_length, len(entity_start_token_idxs))
         all_row_ids.append(row_idx_mapping[doc["row_id"]])
 
-    all_entity_idxs = []
+    all_entity_idx_weights = [] # Used to compute an average of embeddings for the document.
     all_input_ids = []
     all_token_type_ids = []
     all_attention_masks = []
 
     for i, doc_subwords in enumerate(all_doc_subwords):
         entity_start_token_idxs = all_doc_entity_start_positions[i]
-        all_entity_idxs.append(make_fixed_length(entity_start_token_idxs, max_entities_length, padding_value=ENTITY_PAD_IDX))
+        entity_idx_weights = np.zeros((1, max_seq_length))
+        for start_token_idx in entity_start_token_idxs:
+            assert start_token_idx < max_seq_length, "Entity is out of bounds in truncated text seqence, make --max-seq-length larger"
+            entity_idx_weights[0][start_token_idx] = 1.0/len(entity_start_token_idxs)
+        all_entity_idx_weights.append(entity_idx_weights.tolist())
         row = vectorize_subwords(tokenizer, doc_subwords, max_seq_length)
         all_input_ids.append(row.input_ids)
         all_token_type_ids.append(row.segment_ids)
@@ -118,10 +123,10 @@ def construct_dataset(data: List[Dict], tokenizer: AutoTokenizer, row_idx_mappin
     all_token_type_ids = torch.tensor(all_token_type_ids, dtype=torch.long)
     all_attention_masks = torch.tensor(all_attention_masks, dtype=torch.long)
     targets = torch.tensor(targets, dtype=torch.long)
-    all_entity_idxs = torch.tensor(all_entity_idxs, dtype=torch.long)
+    all_entity_idx_weights = torch.tensor(all_entity_idx_weights, dtype=torch.float32)
     all_row_ids = torch.tensor(all_row_ids, dtype=torch.long)
 
-    dataset = TensorDataset(all_input_ids, all_token_type_ids, all_attention_masks, targets, all_entity_idxs, all_row_ids)
+    dataset = TensorDataset(all_input_ids, all_token_type_ids, all_attention_masks, targets, all_entity_idx_weights, all_row_ids)
     return dataset
 
 class DrugSynergyDataModule(pl.LightningDataModule):

--- a/model.py
+++ b/model.py
@@ -87,15 +87,14 @@ class BertForRelation(BertPreTrainedModel):
                             position_ids=input_position)
         sequence_output = outputs[0]
 
-        entity_vectors = []
-        for a, entity_idxs in zip(sequence_output, all_entity_idxs):
-            # We store the entity-of-interest indices as a fixed-dimension matrix with padding indices.
-            # Ignore padding indices when computing the average entity representation.
-            assert torch.max(entity_idxs).item() < self.max_seq_length, "Entity is out of bounds in truncated text seqence, make --max-seq-length larger"
-            entity_idxs = entity_idxs[torch.where(entity_idxs != ENTITY_PAD_IDX)]
-            entity_vectors.append(torch.mean(a[entity_idxs], dim=0).unsqueeze(0))
-        mean_entity_embs = torch.cat(entity_vectors, dim=0)
-        rep = self.layer_norm(mean_entity_embs)
+        sequence_output_transposed = sequence_output.transpose(1, 2)
+        all_entity_idxs_transposed = all_entity_idxs.transpose(1, 2)
+        # all_entity_idxs_transposed contains weighted values of each entity in the document, giving effectively
+        # a weightec average of entity embeddings across the document.
+        entity_vectors = torch.matmul(sequence_output_transposed, all_entity_idxs_transposed)
+        entity_vectors = entity_vectors.squeeze(2) # Squeeze 768 x 1 vector into a single row of dimension 768
+
+        rep = self.layer_norm(entity_vectors)
         rep = self.dropout(rep)
         logits = self.classifier(rep)
         return logits


### PR DESCRIPTION
Compute average entity token embedding using a single batch matrix multiply, instead of manual torch.mean calls in a for loop.

This change works, and the forward pass is considerably faster now. Somehow, overall training time is still only very slightly faster (still investigating)

<img width="708" alt="Screen Shot 2021-08-19 at 11 19 40 PM" src="https://user-images.githubusercontent.com/2577384/130174020-cfa47ef8-a0f0-4256-b502-d56d973cb320.png">
